### PR TITLE
IPC get temporary scale

### DIFF
--- a/CustomizePlus/Api/CustomizePlusIpc.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.cs
@@ -27,6 +27,7 @@ namespace CustomizePlus.Api
 		public const string LabelRevert							= $"CustomizePlus.{nameof(Revert)}";
 		public const string LabelRevertCharacter				= $"CustomizePlus.{nameof(RevertCharacter)}";
 		public const string LabelOnScaleUpdate					= $"CustomizePlus.{nameof(OnScaleUpdate)}";
+		public const string LabelGetTemporaryScale				= $"CustomizePlus.{nameof(GetTemporaryScale)}";
 		private readonly ObjectTable objectTable;
 		private readonly DalamudPluginInterface pluginInterface;
 
@@ -35,6 +36,7 @@ namespace CustomizePlus.Api
 		internal ICallGateProvider<Character?, string?>?		ProviderGetBodyScaleFromCharacter;
 		internal ICallGateProvider<string, string, object>?		ProviderSetBodyScale;
 		internal ICallGateProvider<string, Character?, object>?	ProviderSetBodyScaleToCharacter;
+		internal ICallGateProvider<string, string?>?			ProviderGetTemporaryScale;
 		internal ICallGateProvider<string, object>?				ProviderRevert;
 		internal ICallGateProvider<Character?, object>?			ProviderRevertCharacter;
 		internal ICallGateProvider<string>?						ProviderGetApiVersion;
@@ -60,7 +62,7 @@ namespace CustomizePlus.Api
 			ProviderRevert?.UnregisterAction();
 			ProviderRevertCharacter?.UnregisterAction();
 			ProviderGetApiVersion?.UnregisterFunc();
-
+			ProviderGetTemporaryScale?.UnregisterFunc();
 		}
 
 		private void InitializeProviders()
@@ -148,6 +150,15 @@ namespace CustomizePlus.Api
 				PluginLog.Error(ex, $"Error registering IPC provider for {LabelOnScaleUpdate}.");
 			}
 
+			try
+			{
+				ProviderGetTemporaryScale = pluginInterface.GetIpcProvider<string, string?>(LabelGetTemporaryScale);
+				ProviderGetTemporaryScale.RegisterFunc(GetTemporaryScale);
+			}
+			catch (Exception ex)
+			{
+				PluginLog.Error(ex, $"Error registering IPC provider for {LabelGetTemporaryScale}.");
+			}
 		}
 
 		public void OnScaleUpdate(string bodyScaleString)
@@ -195,6 +206,12 @@ namespace CustomizePlus.Api
 				return;
 
 			Plugin.RemoveTemporaryCharacterScale(characterName);
+		}
+
+		private string? GetTemporaryScale(string characterName)
+		{
+			BodyScale? bodyScale = Plugin.GetTemporaryCharacterScale(characterName);
+			return bodyScale != null ? JsonConvert.SerializeObject(bodyScale) : null;
 		}
 
 		private void RevertCharacter(Character? character)

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -21,11 +21,11 @@ namespace CustomizePlus
 	using Dalamud.IoC;
 	using Dalamud.Logging;
 	using Dalamud.Plugin;
+	using FFXIVClientStructs.FFXIV.Client.System.String;
 	using FFXIVClientStructs.FFXIV.Client.UI;
 	using FFXIVClientStructs.FFXIV.Component.GUI;
 	using Newtonsoft.Json;
-	//using Penumbra.GameData.ByteString;
-	using Penumbra.String;
+	using Penumbra.GameData.ByteString;
 	using CharacterStruct = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
 	using CustomizeData = Penumbra.GameData.Structs.CustomizeData;
 	using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
@@ -309,7 +309,7 @@ namespace CustomizePlus
 
 			try
 			{
-				actorName = new ByteString(gameObject->Name).ToString();
+				actorName = new Utf8String(gameObject->Name).ToString();
 
 				if (string.IsNullOrEmpty(actorName))
 				{
@@ -328,7 +328,7 @@ namespace CustomizePlus
 							244 => GetPlayerName(), // portrait preview
 							>= 200 => GetCutsceneName(gameObject),
 							_ => null,
-						} ?? new ByteString(gameObject->Name).ToString();
+						} ?? new Utf8String(gameObject->Name).ToString();
 					}
 					else
 					{
@@ -336,7 +336,7 @@ namespace CustomizePlus
 						{
 							240 => GetPlayerName(), // character window
 							_ => null,
-						} ?? new ByteString(gameObject->Name).ToString();
+						} ?? new Utf8String(gameObject->Name).ToString();
 					}
 
 					if (actualName == null)
@@ -440,7 +440,7 @@ namespace CustomizePlus
 			}
 
 			var block = data + 0x7A;
-			return new ByteString(block).ToString();
+			return new Utf8String(block).ToString();
 		}
 
 		// Obtain the name of the player character if the glamour plate edit window is open.

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -24,7 +24,8 @@ namespace CustomizePlus
 	using FFXIVClientStructs.FFXIV.Client.UI;
 	using FFXIVClientStructs.FFXIV.Component.GUI;
 	using Newtonsoft.Json;
-	using Penumbra.GameData.ByteString;
+	//using Penumbra.GameData.ByteString;
+	using Penumbra.String;
 	using CharacterStruct = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
 	using CustomizeData = Penumbra.GameData.Structs.CustomizeData;
 	using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
@@ -308,7 +309,7 @@ namespace CustomizePlus
 
 			try
 			{
-				actorName = new Utf8String(gameObject->Name).ToString();
+				actorName = new ByteString(gameObject->Name).ToString();
 
 				if (string.IsNullOrEmpty(actorName))
 				{
@@ -327,7 +328,7 @@ namespace CustomizePlus
 							244 => GetPlayerName(), // portrait preview
 							>= 200 => GetCutsceneName(gameObject),
 							_ => null,
-						} ?? new Utf8String(gameObject->Name).ToString();
+						} ?? new ByteString(gameObject->Name).ToString();
 					}
 					else
 					{
@@ -335,7 +336,7 @@ namespace CustomizePlus
 						{
 							240 => GetPlayerName(), // character window
 							_ => null,
-						} ?? new Utf8String(gameObject->Name).ToString();
+						} ?? new ByteString(gameObject->Name).ToString();
 					}
 
 					if (actualName == null)
@@ -439,7 +440,7 @@ namespace CustomizePlus
 			}
 
 			var block = data + 0x7A;
-			return new Utf8String(block).ToString();
+			return new ByteString(block).ToString();
 		}
 
 		// Obtain the name of the player character if the glamour plate edit window is open.
@@ -457,6 +458,15 @@ namespace CustomizePlus
 			if (string.IsNullOrEmpty(characterName))
 				return;
 			scaleOverride[characterName] = scale;
+		}
+
+		public static BodyScale? GetTemporaryCharacterScale(string characterName)
+		{
+			if (string.IsNullOrEmpty(characterName))
+				return null;
+			if (!scaleOverride.ContainsKey(characterName))
+				return null;
+			return scaleOverride[characterName];
 		}
 
 		public static bool RemoveTemporaryCharacterScale(string characterName)

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -21,7 +21,6 @@ namespace CustomizePlus
 	using Dalamud.IoC;
 	using Dalamud.Logging;
 	using Dalamud.Plugin;
-	using FFXIVClientStructs.FFXIV.Client.System.String;
 	using FFXIVClientStructs.FFXIV.Client.UI;
 	using FFXIVClientStructs.FFXIV.Component.GUI;
 	using Newtonsoft.Json;


### PR DESCRIPTION
Hi there, I'm working on a plugin that has a use for inspecting the scale for a character in the scaleOverrides list. I would appreciate it if I could have an endpoint for retrieving this data from Customize+.

Thanks!