### PR TITLE
Base64 Import and Export from and to Clipboard

### DIFF
--- a/CustomizePlus/CustomizePlus.csproj
+++ b/CustomizePlus/CustomizePlus.csproj
@@ -68,13 +68,15 @@
 	</Reference>
 	<Reference Include="Penumbra">
 	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
-		<Private>false</Private>
+	  <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.GameData">
 	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
+	  <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.String">
-		<HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
+	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
+	  <Private>false</Private>
 	</Reference>
   </ItemGroup>
 

--- a/CustomizePlus/CustomizePlus.csproj
+++ b/CustomizePlus/CustomizePlus.csproj
@@ -68,15 +68,13 @@
 	</Reference>
 	<Reference Include="Penumbra">
 	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
-	  <Private>false</Private>
+		<Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.GameData">
 	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
-	  <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.String">
 	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
-	  <Private>false</Private>
 	</Reference>
   </ItemGroup>
 

--- a/CustomizePlus/CustomizePlus.csproj
+++ b/CustomizePlus/CustomizePlus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.0.1.3</Version>
+    <Version>0.0.1.5</Version>
     <Description>CustomizePlus</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/XIV-Tools/CustomizePlus</PackageProjectUrl>
@@ -18,7 +18,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>$(AppData)\XIVLauncher\devPlugins\CustomizePlus\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -68,11 +67,14 @@
       <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra">
-	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
+	  <HintPath>C:\Users\marth\source\repos\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
 		<Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.GameData">
-	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
+	  <HintPath>C:\Users\marth\source\repos\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
+	</Reference>
+	<Reference Include="Penumbra.String">
+		<HintPath>C:\Users\marth\source\repos\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
 	</Reference>
   </ItemGroup>
 

--- a/CustomizePlus/CustomizePlus.csproj
+++ b/CustomizePlus/CustomizePlus.csproj
@@ -67,14 +67,14 @@
       <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra">
-	  <HintPath>C:\Users\marth\source\repos\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
+	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
 		<Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.GameData">
-	  <HintPath>C:\Users\marth\source\repos\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
+	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
 	</Reference>
 	<Reference Include="Penumbra.String">
-		<HintPath>C:\Users\marth\source\repos\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
+		<HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
 	</Reference>
   </ItemGroup>
 

--- a/CustomizePlus/CustomizePlus.csproj
+++ b/CustomizePlus/CustomizePlus.csproj
@@ -67,15 +67,15 @@
       <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra">
-	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
+	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.dll</HintPath>
 	  <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.GameData">
-	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
+	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.GameData.dll</HintPath>
 	  <Private>false</Private>
 	</Reference>
 	<Reference Include="Penumbra.String">
-	  <HintPath>..\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
+	  <HintPath>..\..\Penumbra\Penumbra\bin\Debug\Penumbra.String.dll</HintPath>
 	  <Private>false</Private>
 	</Reference>
   </ItemGroup>

--- a/CustomizePlus/Interface/ConfigurationInterface.cs
+++ b/CustomizePlus/Interface/ConfigurationInterface.cs
@@ -27,7 +27,7 @@ namespace CustomizePlus.Interface
 		private string newScaleName = string.Empty;
 		private string newScaleCharacter = string.Empty;
 
-		// Change Version when updating the way scales are saved. Import form base64 will then auto fail.
+		// Change Version when updating the way scales are saved. Import from base64 will then auto fail.
 		private byte scaleVersion = 1;
 
 		protected override string Title => "Customize+ Configuration";
@@ -160,29 +160,26 @@ namespace CustomizePlus.Interface
 			if (ImGui.Button("Add Character from Clipboard")) {
 				Byte importVer = 0;
 				string json = null;
-				string characterName = "";
 
 				try {
 					importVer = ImportFromBase64(Clipboard.GetText(),out json);
-					PluginLog.Debug(json);
-					PluginLog.Debug(importVer.ToString());
 					Clipboard.SetText(json);
-				} catch (Exception) {
-					// Something went wrong during Import. Let user know.
+				} catch (Exception e) {
+					PluginLog.Error(e, "An error occured during import conversion. Please check you coppied the right thing!");
 				}
 
 				if (importVer == scaleVersion && json is not null) {
 					BodyScale importScale = BuildFromCustomizeJSON(json);
 					Plugin.Configuration.BodyScales.Add(importScale);
-					Plugin.Configuration.ToggleOffAllOtherMatching(characterName, importScale.ScaleName);
+					Plugin.Configuration.ToggleOffAllOtherMatching(importScale.CharacterName, importScale.ScaleName);
 					if (config.AutomaticEditMode) {
 						config.Save();
 						Plugin.LoadConfig(true);
 					}
 				} else if (importVer == 0 || json is null) {
-					// Something went wrong during Import. Let user know.
+					PluginLog.Error("An error occured during import conversion, but ImportFromBase64 didnt throw an Exception. Please report this to the developers.");
 				} else {
-					// Old version of Scale string used. Let user know.
+					PluginLog.Information("You are trying to import an Outdated scale, these are not supported anymore. Sorry.");
 				}
 			}
 

--- a/CustomizePlus/Interface/ConfigurationInterface.cs
+++ b/CustomizePlus/Interface/ConfigurationInterface.cs
@@ -9,7 +9,6 @@ namespace CustomizePlus.Interface
 	using System.IO.Compression;
 	using System.Numerics;
 	using System.Text;
-	using System.Text.Json.Nodes;
 	using System.Windows.Forms;
     using Anamnesis.Files;
     using Anamnesis.Posing;
@@ -20,7 +19,6 @@ namespace CustomizePlus.Interface
     using Dalamud.Logging;
     using ImGuiNET;
     using Newtonsoft.Json;
-	using static System.Runtime.InteropServices.JavaScript.JSType;
 
 	public class ConfigurationInterface : WindowBase
 	{

--- a/CustomizePlus/Interface/ConfigurationInterface.cs
+++ b/CustomizePlus/Interface/ConfigurationInterface.cs
@@ -35,9 +35,6 @@ namespace CustomizePlus.Interface
 		{
 			Plugin.InterfaceManager.Show<ConfigurationInterface>();
 		}
-		public static void Toggle() {
-			Plugin.InterfaceManager.Toggle<ConfigurationInterface>();
-		}
 
 		protected override void DrawContents()
 		{

--- a/CustomizePlus/Interface/ConfigurationInterface.cs
+++ b/CustomizePlus/Interface/ConfigurationInterface.cs
@@ -35,6 +35,9 @@ namespace CustomizePlus.Interface
 		{
 			Plugin.InterfaceManager.Show<ConfigurationInterface>();
 		}
+		public static void Toggle() {
+			Plugin.InterfaceManager.Toggle<ConfigurationInterface>();
+		}
 
 		protected override void DrawContents()
 		{

--- a/CustomizePlus/Interface/InterfaceBase.cs
+++ b/CustomizePlus/Interface/InterfaceBase.cs
@@ -4,6 +4,7 @@
 namespace CustomizePlus.Interface
 {
 	using System;
+	using Dalamud.Logging;
 	using ImGuiNET;
 
 	public abstract class InterfaceBase : IDisposable

--- a/CustomizePlus/Interface/InterfaceBase.cs
+++ b/CustomizePlus/Interface/InterfaceBase.cs
@@ -4,7 +4,6 @@
 namespace CustomizePlus.Interface
 {
 	using System;
-	using Dalamud.Logging;
 	using ImGuiNET;
 
 	public abstract class InterfaceBase : IDisposable

--- a/CustomizePlus/Interface/InterfaceManager.cs
+++ b/CustomizePlus/Interface/InterfaceManager.cs
@@ -3,7 +3,6 @@
 
 namespace CustomizePlus.Interface
 {
-	using Dalamud.Logging;
 	using System;
 	using System.Collections.Generic;
 
@@ -49,29 +48,6 @@ namespace CustomizePlus.Interface
 				this.interfaces.Add(ui);
 
 			return ui;
-		}
-
-		// Added this so you can close with /customize. This may need a rework in the future to access the broader usecase of the rest of the methods. But this should serve for now?
-		public void Toggle<T>()
-			where T : InterfaceBase, new()
-		{
-			if (this.interfaces.Count <= 0)
-				new InvalidOperationException("Interfaces is empty.");
-
-			bool switchedOff = false;
-
-			// Close all windows, if we closed any window set 'switchedOff' to true so we know we are in the Turning off phase.
-			for (int i = this.interfaces.Count - 1;i >= 0;i--) {
-				if (this.interfaces[i].IsOpen) {
-					this.interfaces[i].Close();
-					switchedOff = true;
-				}
-			}
-
-			// If we did not turn anything off, we probably want to show our window.
-			if (!switchedOff) {
-				Show<T>();
-			}
 		}
 
 		public InterfaceBase? GetInterface(Type type)

--- a/CustomizePlus/Interface/InterfaceManager.cs
+++ b/CustomizePlus/Interface/InterfaceManager.cs
@@ -3,6 +3,7 @@
 
 namespace CustomizePlus.Interface
 {
+	using Dalamud.Logging;
 	using System;
 	using System.Collections.Generic;
 
@@ -48,6 +49,29 @@ namespace CustomizePlus.Interface
 				this.interfaces.Add(ui);
 
 			return ui;
+		}
+
+		// Added this so you can close with /customize. This may need a rework in the future to access the broader usecase of the rest of the methods. But this should serve for now?
+		public void Toggle<T>()
+			where T : InterfaceBase, new()
+		{
+			if (this.interfaces.Count <= 0)
+				new InvalidOperationException("Interfaces is empty.");
+
+			bool switchedOff = false;
+
+			// Close all windows, if we closed any window set 'switchedOff' to true so we know we are in the Turning off phase.
+			for (int i = this.interfaces.Count - 1;i >= 0;i--) {
+				if (this.interfaces[i].IsOpen) {
+					this.interfaces[i].Close();
+					switchedOff = true;
+				}
+			}
+
+			// If we did not turn anything off, we probably want to show our window.
+			if (!switchedOff) {
+				Show<T>();
+			}
 		}
 
 		public InterfaceBase? GetInterface(Type type)

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -50,10 +50,10 @@ namespace CustomizePlus
 
 				LoadConfig();
 
-				CommandManager.AddCommand((s, t) => ConfigurationInterface.Toggle(), "/customize", "Opens the Customize+ configuration window.");
+				CommandManager.AddCommand((s, t) => ConfigurationInterface.Show(), "/customize", "Opens the Customize+ configuration window.");
 
 				PluginInterface.UiBuilder.Draw += InterfaceManager.Draw;
-				PluginInterface.UiBuilder.OpenConfigUi += ConfigurationInterface.Toggle;
+				PluginInterface.UiBuilder.OpenConfigUi += ConfigurationInterface.Show;
 
 				if (PluginInterface.IsDevMenuOpen)
 					ConfigurationInterface.Show();

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -24,7 +24,7 @@ namespace CustomizePlus
 	using FFXIVClientStructs.FFXIV.Client.UI;
 	using FFXIVClientStructs.FFXIV.Component.GUI;
 	using Newtonsoft.Json;
-	using Penumbra.GameData.ByteString;
+	using Penumbra.String;
 	using CharacterStruct = FFXIVClientStructs.FFXIV.Client.Game.Character.Character;
 	using CustomizeData = Penumbra.GameData.Structs.CustomizeData;
 	using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
@@ -308,7 +308,7 @@ namespace CustomizePlus
 
 			try
 			{
-				actorName = new Utf8String(gameObject->Name).ToString();
+				actorName = new ByteString(gameObject->Name).ToString();
 
 				if (string.IsNullOrEmpty(actorName))
 				{
@@ -327,7 +327,7 @@ namespace CustomizePlus
 							244 => GetPlayerName(), // portrait preview
 							>= 200 => GetCutsceneName(gameObject),
 							_ => null,
-						} ?? new Utf8String(gameObject->Name).ToString();
+						} ?? new ByteString(gameObject->Name).ToString();
 					}
 					else
 					{
@@ -335,7 +335,7 @@ namespace CustomizePlus
 						{
 							240 => GetPlayerName(), // character window
 							_ => null,
-						} ?? new Utf8String(gameObject->Name).ToString();
+						} ?? new ByteString(gameObject->Name).ToString();
 					}
 
 					if (actualName == null)
@@ -439,7 +439,7 @@ namespace CustomizePlus
 			}
 
 			var block = data + 0x7A;
-			return new Utf8String(block).ToString();
+			return new ByteString(block).ToString();
 		}
 
 		// Obtain the name of the player character if the glamour plate edit window is open.

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -50,10 +50,10 @@ namespace CustomizePlus
 
 				LoadConfig();
 
-				CommandManager.AddCommand((s, t) => ConfigurationInterface.Show(), "/customize", "Opens the Customize+ configuration window.");
+				CommandManager.AddCommand((s, t) => ConfigurationInterface.Toggle(), "/customize", "Opens the Customize+ configuration window.");
 
 				PluginInterface.UiBuilder.Draw += InterfaceManager.Draw;
-				PluginInterface.UiBuilder.OpenConfigUi += ConfigurationInterface.Show;
+				PluginInterface.UiBuilder.OpenConfigUi += ConfigurationInterface.Toggle;
 
 				if (PluginInterface.IsDevMenuOpen)
 					ConfigurationInterface.Show();


### PR DESCRIPTION
This implements the ability to export scales to a compressed Byte Array in base64 and import self same again. 
Works by robbed functions from Otter.

I also was so free as to update some deprecated functions from Penumbra. 