### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Customize+ is a plugin for Dalamud that allows you to create and apply [Anamnesi
 
 ### Installing
 Add the following URL to the Dalamud Custom Plugin Repositories list:  
-`https://raw.githubusercontent.com/XIV-Tools/DalamudPlugins/main/repo.json`
-And search for Customize+ in the plugin manager.
+`https://raw.githubusercontent.com/XIV-Tools/DalamudPlugins/main/repo.json`  
+Then search for Customize+ in the plugin manager.
 
 ### How do I report an issue with Customize+?
 Please use the [Issue tab](https://github.com/XIV-Tools/CustomizePlus/issues) to report issues with Customize+. Issues reported on Discord will be removed.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Customize+
 Customize+ is a plugin for Dalamud that allows you to create and apply [Anamnesis](https://github.com/imchillin/Anamnesis)-style body scaling full time.
 
-### Installing Alpha Builds
+### Installing
 Add the following URL to the Dalamud Custom Plugin Repositories list:  
 `https://raw.githubusercontent.com/XIV-Tools/DalamudPlugins/main/repo.json`
 And search for Customize+ in the plugin manager.
@@ -10,7 +10,7 @@ And search for Customize+ in the plugin manager.
 Please use the [Issue tab](https://github.com/XIV-Tools/CustomizePlus/issues) to report issues with Customize+. Issues reported on Discord will be removed.
 
 ### Where do I learn how to use Customize+?
-Customize+ is in an alpha state, and is released more as a proof of concept, so is not intended for widespread use. As such, there is no documentation outlining how to use the tool, as this may not be for you unless you yourself are a developer and are interested in contributing.
+Most of the things should be self-explanatory, if you do need help you can join the [XIV Tools Discord](https://discord.gg/xivtools) and self assign yourself the Customize+ role and ask in the appropriate channel.
 
-### When will it be fully released?
-A release date cannot be forecast this early on, as this is an infant project worked on in the developers' free time. Real life and paid employment take priority over development of free tools for a subscription MMO for which the developers receive no compensation.
+### When will it be updated?
+Release dates cannot be forecast, as this is a project worked on in the developers' free time. Real life and paid employment take priority over development of free tools for a subscription MMO for which the developers receive no compensation.


### PR DESCRIPTION
It has come to my attention that there was no Discord link on the github page. Leading people to ask questions on Mare, Penumbra and other discords. To stop that I added the link, while doing so I thought we could remove the Alpha claims from the page. While its a cozy claim I dont think this plugin can claim to "not be for widespread use" anymore. :) 