### PR TITLE
[Live version] Added profile version check in preparations for 0.0.2.0 testing

### DIFF
--- a/CustomizePlus/BodyScale.cs
+++ b/CustomizePlus/BodyScale.cs
@@ -29,6 +29,7 @@ namespace CustomizePlus
 		public string CharacterName;
 		public string ScaleName;
 		public bool BodyScaleEnabled;
+		public int ConfigVersion { get; set; } = Constants.ConfigurationVersion;
 
 		public Dictionary<string, BoneEditsContainer> Bones { get; private set; } = new();
 


### PR DESCRIPTION
This PR contains some code which will make sure live version users who use mare will not encounter any issues when encountering people who are using incoming 0.0.2.0 testing version. (they just won't see their profile)

This needs to be released in advance before 0.0.2.0 testing begins.