### PR TITLE
Application of C+ to GameObjects & adjustments for Mare

### DIFF
--- a/CustomizePlus/Core/ServiceManager.cs
+++ b/CustomizePlus/Core/ServiceManager.cs
@@ -22,6 +22,7 @@ namespace CustomizePlus.Core
             Add<GPoseService>();
             Add<GPoseAmnesisKtisisWarningService>();
             Add<PosingModeDetectService>();
+            Add<PlayerOwnedObjectsService>();
         }
 
         //--------

--- a/CustomizePlus/Data/Armature/ArmatureManager.cs
+++ b/CustomizePlus/Data/Armature/ArmatureManager.cs
@@ -69,6 +69,8 @@ namespace CustomizePlus.Data.Armature
 
         private unsafe void ApplyArmatureTransforms()
         {
+            Plugin.ProfileManager.ResetTempCharacters();
+
             foreach(GameObject obj in DalamudServices.ObjectTable)
             {
                 CharacterProfile? prof = Plugin.ProfileManager
@@ -82,6 +84,8 @@ namespace CustomizePlus.Data.Armature
                     prof.Armature.ApplyPiecewiseTransformation(obj);
                 }
             }
+
+            Plugin.ProfileManager.ClearUnusedTempCharacters();
         }
     }
 }

--- a/CustomizePlus/Data/Armature/ArmatureManager.cs
+++ b/CustomizePlus/Data/Armature/ArmatureManager.cs
@@ -5,11 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CustomizePlus.Data.Profile;
-using CustomizePlus.Helpers;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Logging;
-
-using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 
 namespace CustomizePlus.Data.Armature
 {
@@ -49,7 +46,7 @@ namespace CustomizePlus.Data.Armature
                 ConstructArmatureForProfile(prof);
             }
 
-            foreach(var arm in _armatures.Except(profiles.Select(x => x.Armature)))
+            foreach (var arm in _armatures.Except(profiles.Select(x => x.Armature)))
             {
                 if (arm != null && _armatures.Remove(arm))
                 {
@@ -71,7 +68,7 @@ namespace CustomizePlus.Data.Armature
         {
             Plugin.ProfileManager.ResetTempCharacters();
 
-            foreach(GameObject obj in DalamudServices.ObjectTable)
+            foreach (GameObject obj in DalamudServices.ObjectTable)
             {
                 CharacterProfile? prof = Plugin.ProfileManager
                     .GetProfilesByGameObject(obj)
@@ -79,7 +76,9 @@ namespace CustomizePlus.Data.Armature
 
                 if (prof != null
                     && prof.Armature != null
-                    && prof.Armature.IsVisible)
+                    && prof.Armature.IsVisible 
+                    && (!prof.OwnedOnly
+                        || (prof.OwnedOnly && Services.PlayerOwnedObjectsService.Instance.PlayerOwnedObjects.Contains(obj.Address))))
                 {
                     prof.Armature.ApplyPiecewiseTransformation(obj);
                 }

--- a/CustomizePlus/Data/Profile/CharacterProfile.cs
+++ b/CustomizePlus/Data/Profile/CharacterProfile.cs
@@ -37,6 +37,7 @@ namespace CustomizePlus.Data.Profile
             ProfileName = original.ProfileName;
             ConfigVersion = original.ConfigVersion;
             Enabled = original.Enabled;
+            OwnedOnly = original.OwnedOnly;
             CreationDate = original.CreationDate;
             ModifiedDate = DateTime.Now;
             OriginalFilePath = original.OriginalFilePath;
@@ -51,6 +52,7 @@ namespace CustomizePlus.Data.Profile
 
         public string CharacterName { get; set; } = "Default";
         public string ProfileName { get; set; } = "Profile";
+        public bool OwnedOnly { get; set; } = false;
         public int ConfigVersion { get; set; } = Constants.ConfigurationVersion;
         public bool Enabled { get; set; }
         public DateTime CreationDate { get; set; } = DateTime.Now;

--- a/CustomizePlus/Data/Profile/ProfileManager.cs
+++ b/CustomizePlus/Data/Profile/ProfileManager.cs
@@ -16,14 +16,12 @@ namespace CustomizePlus.Data.Profile
     {
         private class TempCharacter
         {
-            public TempCharacter(string? name, nint? address)
+            public TempCharacter(nint address)
             {
-                Name = name;
                 Address = address;
             }
 
-            public string? Name { get; init; }
-            public nint? Address { get; init; }
+            public nint Address { get; init; }
             public bool Processed { get; set; }
         }
 
@@ -268,7 +266,7 @@ namespace CustomizePlus.Data.Profile
             else
             {
                 Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara}", characterAddress);
-                TempLocalProfiles[new TempCharacter(null, characterAddress)] = prof;
+                TempLocalProfiles[new TempCharacter(characterAddress)] = prof;
             }
         }
 
@@ -376,10 +374,10 @@ namespace CustomizePlus.Data.Profile
                 }
             }
 
-            var hasTempProfile = TempLocalProfiles.Any(f => f.Key.Name == name || obj.Address == f.Key.Address);
+            var hasTempProfile = TempLocalProfiles.Any(f => obj.Address == f.Key.Address);
             if (hasTempProfile)
             {
-                var matchingProfile = TempLocalProfiles.First(f => f.Key.Name == name || obj.Address == f.Key.Address);
+                var matchingProfile = TempLocalProfiles.First(f => obj.Address == f.Key.Address);
                 matchingProfile.Key.Processed = true;
                 output.Add(matchingProfile.Value);
                 return output;

--- a/CustomizePlus/Data/Profile/ProfileManager.cs
+++ b/CustomizePlus/Data/Profile/ProfileManager.cs
@@ -272,34 +272,6 @@ namespace CustomizePlus.Data.Profile
             }
         }
 
-        public void AddTemporaryProfile(string characterName, CharacterProfile prof)
-        {
-            var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Name == characterName);
-            if (key != null)
-            {
-                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for chara {chara}", characterName);
-                TempLocalProfiles[key] = prof;
-            }
-            else
-            {
-                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for chara {chara}", characterName);
-                TempLocalProfiles[new TempCharacter(characterName, null)] = prof;
-            }
-        }
-
-        public void RemoveTemporaryProfile(string characterName)
-        {
-            var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Name == characterName);
-            if (key != default)
-            {
-                Dalamud.Logging.PluginLog.LogInformation("Removing temp profile for chara {chara}", characterName);
-                if(!TempLocalProfiles.Remove(key))
-                {
-                    Dalamud.Logging.PluginLog.LogInformation("Could not remove chara {chara}", characterName);
-                }
-            }
-        }
-
         public void RemoveTemporaryProfile(nint address)
         {
             var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Address == address);

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -147,8 +147,7 @@ namespace CustomizePlus
                     _renderManagerHook.Enable();
 
                     //Send current player's profile update message to IPC
-                    // todo: send all active profiles to ipc
-                    //IPCManager.OnProfileUpdate();
+                    IPCManager.OnProfileUpdate(null);
                 }
                 else
                 {

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -147,7 +147,8 @@ namespace CustomizePlus
                     _renderManagerHook.Enable();
 
                     //Send current player's profile update message to IPC
-                    IPCManager.OnLocalPlayerProfileUpdate();
+                    // todo: send all active profiles to ipc
+                    //IPCManager.OnProfileUpdate();
                 }
                 else
                 {

--- a/CustomizePlus/Services/PlayerOwnedObjectsService.cs
+++ b/CustomizePlus/Services/PlayerOwnedObjectsService.cs
@@ -1,0 +1,50 @@
+﻿using CustomizePlus.Core;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using System.Collections.Generic;
+
+namespace CustomizePlus.Services
+{
+    internal class PlayerOwnedObjectsService : ServiceBase<PlayerOwnedObjectsService>
+    {
+        public List<nint> PlayerOwnedObjects { get; private set; } = new();
+        public override void Tick(float delta)
+        {
+            PlayerOwnedObjects.Clear();
+
+            var player = DalamudServices.ClientState.LocalPlayer;
+            if (player == null) return;
+
+            var playerPointer = player.Address;
+            PlayerOwnedObjects.Add(playerPointer);
+
+            var minion = GetMinionOrMount(playerPointer);
+            if (minion != nint.Zero) PlayerOwnedObjects.Add(minion);
+
+            var pet = GetPet(playerPointer);
+            if (pet != nint.Zero) PlayerOwnedObjects.Add(pet);
+
+            var companion = GetCompanion(playerPointer);
+            if (companion != nint.Zero) PlayerOwnedObjects.Add(companion);
+        }
+
+        private unsafe nint GetMinionOrMount(nint playerPointer)
+        {
+            return DalamudServices.ObjectTable.GetObjectAddress(((GameObject*)playerPointer)->ObjectIndex + 1);
+        }
+
+        private unsafe nint GetPet(nint playerPointer)
+        {
+            var mgr = CharacterManager.Instance();
+            if ((nint)mgr == nint.Zero) return nint.Zero;
+            return (nint)mgr->LookupPetByOwnerObject((BattleChara*)playerPointer);
+        }
+
+        private unsafe nint GetCompanion(nint playerPointer)
+        {
+            var mgr = CharacterManager.Instance();
+            if ((nint)mgr == nint.Zero) return nint.Zero;
+            return (nint)mgr->LookupBuddyByOwnerObject((BattleChara*)playerPointer);
+        }
+    }
+}

--- a/CustomizePlus/UI/Windows/MainWindow.cs
+++ b/CustomizePlus/UI/Windows/MainWindow.cs
@@ -204,8 +204,7 @@ namespace CustomizePlus.UI.Windows
                         prof.Enabled = tempEnabled;
 
                         //Send OnProfileUpdate if this is profile of the current player
-                        if (prof.CharacterName == GameDataHelper.GetPlayerName())
-                            Plugin.IPCManager.OnLocalPlayerProfileUpdate();
+                        Plugin.IPCManager.OnProfileUpdate(prof);
                     }
 
                     if (ImGui.IsItemHovered())

--- a/CustomizePlus/UI/Windows/MainWindow.cs
+++ b/CustomizePlus/UI/Windows/MainWindow.cs
@@ -151,12 +151,13 @@ namespace CustomizePlus.UI.Windows
             //TODO there's probably some imgui functionality to sort the table when you click on the headers
 
             var fontScale = ImGui.GetIO().FontGlobalScale;
-            if (ImGui.BeginTable("Config", 5,
+            if (ImGui.BeginTable("Config", 6,
                     ImGuiTableFlags.Borders | ImGuiTableFlags.Resizable | ImGuiTableFlags.ScrollY |
                     ImGuiTableFlags.Sortable,
                     new Vector2(0, ImGui.GetFrameHeightWithSpacing() - 70 * fontScale)))
             {
                 ImGui.TableSetupColumn("Enabled", ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.NoResize);
+                ImGui.TableSetupColumn("Only Owned", ImGuiTableColumnFlags.WidthFixed | ImGuiTableColumnFlags.NoResize);
                 ImGui.TableSetupColumn("Character",
                     ImGuiTableColumnFlags.WidthStretch | ImGuiTableColumnFlags.DefaultSort);
                 ImGui.TableSetupColumn("Profile Name", ImGuiTableColumnFlags.WidthStretch);
@@ -172,8 +173,9 @@ namespace CustomizePlus.UI.Windows
                 Func<CharacterProfile, IComparable> sortByAttribute = sortSpecs.ColumnIndex switch
                 {
                     0 => x => x.Enabled ? 0 : 1,
-                    1 => x => x.CharacterName,
-                    2 => x => x.ProfileName,
+                    1 => x => x.OwnedOnly ? 0 : 1,
+                    2 => x => x.CharacterName,
+                    3 => x => x.ProfileName,
                     _ => x => x.CharacterName
                 };
 
@@ -210,6 +212,22 @@ namespace CustomizePlus.UI.Windows
                     if (ImGui.IsItemHovered())
                     {
                         ImGui.SetTooltip("Enable and disable profile.\nOnly one profile can be active per character.");
+                    }
+
+                    // Owned only
+                    ImGui.TableNextColumn();
+                    ImGui.Dummy(new Vector2((ImGui.GetContentRegionAvail().X - (ImGui.GetStyle().CellPadding.X * 2) - CtrlHelper.IconButtonWidth) / 2, 0));
+                    ImGui.SameLine();
+                    var ownedOnly = prof.OwnedOnly;
+                    if (ImGui.Checkbox("##OwnedOnly", ref ownedOnly))
+                    {
+                        prof.OwnedOnly = ownedOnly;
+                    }
+
+
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip("This will only apply to player owned objects, like Pets, Minions, etc.");
                     }
 
                     // ---


### PR DESCRIPTION
This PR is primarily an update for Mare Synchronos.

It affects the following:
- Addition of 'Owned Only' toggle: in the main UI toggling this allows application of Customize+ scaling to only your own objects instead of every same named object in the world
- Character-based assignments: instead of tracking by Name it is now possible to track Customize+ entities by gameobject addresses, which is relevant to be able to assign profiles to temporary Character objects through IPC
- Adjustment of IPC: redundant and obsolete IPC not used by Mare has been removed