### PR TITLE
Re-added check for 0,0,0 scaling.

### DIFF
--- a/CustomizePlus/Data/Armature/Armature.cs
+++ b/CustomizePlus/Data/Armature/Armature.cs
@@ -401,7 +401,10 @@ namespace CustomizePlus.Data.Armature
                         //the main root bone's position information is handled by a different hook
                         //so there's no point in trying to update it here
                         //meanwhile root scaling has special rules
-
+                        if (mb.CustomizedTransform.Scaling.X == 0 &&
+                            mb.CustomizedTransform.Scaling.Y == 0 &&
+                            mb.CustomizedTransform.Scaling.Z == 0)
+                            continue;
                         if (obj.HasScalableRoot() && cBase->DrawObject.IsVisible)
                             cBase->DrawObject.Object.Scale = mb.CustomizedTransform.Scaling;
                     }
@@ -439,8 +442,11 @@ namespace CustomizePlus.Data.Armature
                             {
                                 if (mb == MainRootBone)
                                 {
-                                    if (obj.HasScalableRoot())
-                                        cBase->DrawObject.Object.Scale= mb.CustomizedTransform.Scaling;
+                                    if (obj.HasScalableRoot() &&
+                                        (mb.CustomizedTransform.Scaling.X != 0 ||
+                                        mb.CustomizedTransform.Scaling.Y != 0 ||
+                                        mb.CustomizedTransform.Scaling.Z != 0))
+                                        cBase->DrawObject.Object.Scale = mb.CustomizedTransform.Scaling;
                                 }
                                 else
                                 {

--- a/CustomizePlus/Data/Armature/Armature.cs
+++ b/CustomizePlus/Data/Armature/Armature.cs
@@ -401,9 +401,7 @@ namespace CustomizePlus.Data.Armature
                         //the main root bone's position information is handled by a different hook
                         //so there's no point in trying to update it here
                         //meanwhile root scaling has special rules
-                        if (mb.CustomizedTransform.Scaling.X == 0 &&
-                            mb.CustomizedTransform.Scaling.Y == 0 &&
-                            mb.CustomizedTransform.Scaling.Z == 0)
+                        if (!IsModifiedScale(mb))
                             continue;
                         if (obj.HasScalableRoot() && cBase->DrawObject.IsVisible)
                             cBase->DrawObject.Object.Scale = mb.CustomizedTransform.Scaling;
@@ -414,6 +412,18 @@ namespace CustomizePlus.Data.Armature
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks for a non-zero and non-identity (root) scale.
+        /// </summary>
+        /// <param name="mb">The bone to check</param>
+        /// <returns>If the scale should be applied.</returns>
+        private static bool IsModifiedScale(ModelBone mb)
+        {
+            return (mb.CustomizedTransform.Scaling.X != 0 && mb.CustomizedTransform.Scaling.X != 1) ||
+                   (mb.CustomizedTransform.Scaling.Y != 0 && mb.CustomizedTransform.Scaling.Y != 1) ||
+                   (mb.CustomizedTransform.Scaling.Z != 0 && mb.CustomizedTransform.Scaling.Z != 1);
         }
 
 
@@ -442,10 +452,7 @@ namespace CustomizePlus.Data.Armature
                             {
                                 if (mb == MainRootBone)
                                 {
-                                    if (obj.HasScalableRoot() &&
-                                        (mb.CustomizedTransform.Scaling.X != 0 ||
-                                        mb.CustomizedTransform.Scaling.Y != 0 ||
-                                        mb.CustomizedTransform.Scaling.Z != 0))
+                                    if (obj.HasScalableRoot() && IsModifiedScale(mb))
                                         cBase->DrawObject.Object.Scale = mb.CustomizedTransform.Scaling;
                                 }
                                 else


### PR DESCRIPTION
I re-added the workaround for 0,0,0 scaling to be a special case, as was performed [here on the old /main version.](https://github.com/XIV-Tools/CustomizePlus/blob/0cb0997f85defb44895d49de7dce9c95dd3c9972/CustomizePlus/BodyScale.cs#L288) This special case allows for entities whose scale is set to 0,0,0 to use the game's scaling, avoiding issues with debuffs like Minimum or P12S-2. I opted to also modify the code for Armature.ApplyTransformation as well, even though it doesn't appear to be in use currently. I also opted to match the original check, of a full 0,0,0, rather than individual 0s on any axis, though the original code also forces the scales to a floor value.