### PR TITLE
Allow scales to be loaded via MCDF files

### DIFF
--- a/CustomizePlus/Data/Profile/CharacterProfile.cs
+++ b/CustomizePlus/Data/Profile/CharacterProfile.cs
@@ -56,6 +56,7 @@ namespace CustomizePlus.Data.Profile
 
         public string CharacterName { get; set; } = "Default";
         public string ProfileName { get; set; } = "Profile";
+        public nint? Address { get; set; } = null;
         public bool OwnedOnly { get; set; } = false;
         public int ConfigVersion { get; set; } = Constants.ConfigurationVersion;
         public bool Enabled { get; set; }
@@ -76,6 +77,8 @@ namespace CustomizePlus.Data.Profile
         /// </summary>
         public bool AppliesTo(Dalamud.Game.ClientState.Objects.Types.GameObject obj)
         {
+            if (Address != null && obj.Address == Address) return true;
+            
             //PluginLog.Verbose($"Checking on {obj.ObjectIndex} for scale {ProfileName}");
             if (obj.Name.TextValue.IsNullOrEmpty() && (obj.ObjectIndex == 200 || obj.ObjectIndex == 201))
             {

--- a/CustomizePlus/Data/Profile/ProfileManager.cs
+++ b/CustomizePlus/Data/Profile/ProfileManager.cs
@@ -263,6 +263,8 @@ namespace CustomizePlus.Data.Profile
 
         public void AddTemporaryProfile(nint characterAddress, CharacterProfile prof)
         {
+            prof.Enabled = true;
+            prof.Address = characterAddress;
             var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Address == characterAddress);
             if (key != null)
             {


### PR DESCRIPTION
There was an issue since the temp profiles loaded via IPC are done via an actor address not by name.

For this case, what has been done is when an actor is created, the profile contains the actor address, and if that is set and the actors match in the `CharacterProfile.AppliesTo(Dalamud.Game.ClientState.Objects.Types.GameObject)` call, the profile is marked as applicable.