### PR TITLE
Fix up applying scales applied via IPC when entering gpose

### DIFF
--- a/CustomizePlus/CustomizePlus.csproj
+++ b/CustomizePlus/CustomizePlus.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>1.2.6.0</Version>
+    <Version>1.2.6.1</Version>
     <Description>CustomizePlus</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/XIV-Tools/CustomizePlus</PackageProjectUrl>

--- a/CustomizePlus/Data/Profile/ProfileManager.cs
+++ b/CustomizePlus/Data/Profile/ProfileManager.cs
@@ -270,12 +270,12 @@ namespace CustomizePlus.Data.Profile
             var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Address == characterAddress);
             if (key != null)
             {
-                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for addr {chara} {charName}", characterAddress, prof.CharacterName);
+                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for addr {chara}", characterAddress);
                 TempLocalProfiles[key] = prof;
             }
             else
             {
-                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara} {charName}", characterAddress, prof.CharacterName);
+                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara}", characterAddress);
                 TempLocalProfiles[new TempCharacter(characterAddress)] = prof;
             }
         }

--- a/CustomizePlus/Data/Profile/ProfileManager.cs
+++ b/CustomizePlus/Data/Profile/ProfileManager.cs
@@ -266,20 +266,16 @@ namespace CustomizePlus.Data.Profile
         {
             prof.Enabled = true;
             prof.Address = characterAddress;
-            var characterNameApplied = DalamudServices.ObjectTable.FirstOrDefault(x => x.Address == characterAddress)?.Name.TextValue;
-            
-            if (characterNameApplied != null)
-                prof.CharacterName = characterNameApplied;
 
             var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Address == characterAddress);
             if (key != null)
             {
-                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for addr {chara} {charName}", characterAddress, characterNameApplied ?? "unknown name");
+                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for addr {chara} {charName}", characterAddress, prof.CharacterName);
                 TempLocalProfiles[key] = prof;
             }
             else
             {
-                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara} {charName}", characterAddress, characterNameApplied ?? "unknown name");
+                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara} {charName}", characterAddress, prof.CharacterName);
                 TempLocalProfiles[new TempCharacter(characterAddress)] = prof;
             }
         }

--- a/CustomizePlus/Data/Profile/ProfileManager.cs
+++ b/CustomizePlus/Data/Profile/ProfileManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using CustomizePlus.Helpers;
+using CustomizePlus.Services;
 using Dalamud.Game.ClientState.Objects.Enums;
 
 namespace CustomizePlus.Data.Profile
@@ -265,15 +266,20 @@ namespace CustomizePlus.Data.Profile
         {
             prof.Enabled = true;
             prof.Address = characterAddress;
+            var characterNameApplied = DalamudServices.ObjectTable.FirstOrDefault(x => x.Address == characterAddress)?.Name.TextValue;
+            
+            if (characterNameApplied != null)
+                prof.CharacterName = characterNameApplied;
+
             var key = TempLocalProfiles.Keys.FirstOrDefault(f => f.Address == characterAddress);
             if (key != null)
             {
-                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for addr {chara}", characterAddress);
+                Dalamud.Logging.PluginLog.LogInformation("Replacing temp profile for addr {chara} {charName}", characterAddress, characterNameApplied ?? "unknown name");
                 TempLocalProfiles[key] = prof;
             }
             else
             {
-                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara}", characterAddress);
+                Dalamud.Logging.PluginLog.LogInformation("Setting temp profile for addr {chara} {charName}", characterAddress, characterNameApplied ?? "unknown name");
                 TempLocalProfiles[new TempCharacter(characterAddress)] = prof;
             }
         }
@@ -382,12 +388,11 @@ namespace CustomizePlus.Data.Profile
                 }
             }
 
-            var hasTempProfile = TempLocalProfiles.Any(f => obj.Address == f.Key.Address);
-            if (hasTempProfile)
+            var (tempCharacter, matchingProfile) = TempLocalProfiles.FirstOrDefault(f => obj.Address == f.Key.Address || (obj.ObjectIndex is >= 200 and < 300 && f.Value.AppliesTo(obj)));
+            if (matchingProfile != null)
             {
-                var matchingProfile = TempLocalProfiles.First(f => obj.Address == f.Key.Address);
-                matchingProfile.Key.Processed = true;
-                output.Add(matchingProfile.Value);
+                tempCharacter.Processed = true;
+                output.Add(matchingProfile);
                 return output;
             }
 


### PR DESCRIPTION
This defers to using name based matching for characters where `ObjectIndex `is 2xx as gpose actors are clones of the PCs in the 200 range, and therefore have a different address.